### PR TITLE
Refactor: Remove non-value-adding comments and add docs

### DIFF
--- a/agent/coordinator/sub_agents/tech_news_agent.py
+++ b/agent/coordinator/sub_agents/tech_news_agent.py
@@ -19,10 +19,6 @@ def fetch_feed(uri: str) -> dict:
     """
     feed = parse(uri)
     if feed.bozo != 1:
-        # if before:
-        #     feed.entries = [entry for entry in feed.entries if datetime.datetime(*entry.published_parsed[:6]) < before]
-        # if after:
-        #     feed.entries = [entry for entry in feed.entries if datetime.datetime(*entry.published_parsed[:6]) > after]
         return {
             "status": "success",
             "message": f"Successfully fetched feed from {uri}",

--- a/front/components/ChatMessageInput.jsx
+++ b/front/components/ChatMessageInput.jsx
@@ -1,4 +1,3 @@
-// components/ChatMessageInput.js
 'use client';
 
 import React, { useState, forwardRef } from 'react';
@@ -111,7 +110,6 @@ const ChatMessageInput = forwardRef(
               <Send className="h-5 w-5" />
             )}
           </Button>
-          {/* Shortcut Hint */}
           <div className="absolute right-[calc(--spacing(4)+40px)] top-1/2 transform -translate-y-1/2 text-xs text-gray-600 pointer-events-none md:block hidden">
             <kbd className="px-2 py-0.5 border border-gray-700 bg-gray-800 rounded">
               Ctrl

--- a/front/components/ChatMessagesDisplay.jsx
+++ b/front/components/ChatMessagesDisplay.jsx
@@ -1,10 +1,27 @@
-// components/ChatMessagesDisplay.js
 'use client';
 
 import React, { useEffect, useRef } from 'react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
 
+/**
+ * @typedef {object} Message
+ * @property {string} id - Unique identifier for the message.
+ * @property {'user' | 'model' | 'system'} role - The role of the message sender.
+ * @property {string} text - The content of the message. HTML is allowed for 'model' role.
+ */
+
+/**
+ * @typedef {object} ChatMessagesDisplayProps
+ * @property {Message[]} messages - An array of message objects to display.
+ * @property {boolean} isBotTyping - Flag to indicate if the bot is currently typing.
+ */
+
+/**
+ * Renders a list of chat messages and a typing indicator.
+ * Automatically scrolls to the latest message.
+ * @param {ChatMessagesDisplayProps} props - The props for the component.
+ */
 const ChatMessagesDisplay = ({ messages, isBotTyping }) => {
   // Added isBotTyping prop
   const scrollAreaViewportRef = useRef(null);
@@ -70,10 +87,6 @@ const ChatMessagesDisplay = ({ messages, isBotTyping }) => {
                 <span className="typing-dot"></span>
                 <span className="typing-dot"></span>
               </div>
-              {/* Optional: "Bot is typing..." text, can be removed if dots are enough */}
-              {/* <span className="text-xs opacity-70 block text-right mt-1">
-                Bot is typing...
-              </span> */}
             </div>
           </div>
         )}

--- a/front/components/ConsentPopup.jsx
+++ b/front/components/ConsentPopup.jsx
@@ -18,6 +18,13 @@ import { useUserProfile } from '@/components/UserProfileProvider'; // Your conte
 import { callAuthenticatedApi } from '@/lib/apiClient'; // Your API client
 import { useRouter } from 'next/navigation';
 
+/**
+ * @file Renders a modal dialog to manage user consent for cookies and
+ * optionally allow them to create an organization.
+ * It interacts with NextAuth for session data and UserProfileProvider for profile updates.
+ * The dialog is displayed based on the user's authentication status and consent state
+ * stored in their profile.
+ */
 export default function ConsentPopup() {
   // session for auth status, profile for app-specific data including consent
   const { data: session, status: sessionStatus } = useSession();

--- a/functions/users/main.py
+++ b/functions/users/main.py
@@ -16,15 +16,12 @@ from flask import request
 from google.cloud import firestore
 
 
-# Initialize Firestore client
 db = firestore.Client()
 
-# Configuration
 ALLOWED_ORIGINS = os.getenv("CORS_ALLOWED_ORIGINS", "*")
 X_APIGATEWAY_USERINFO_HEADER = "X-Apigateway-Api-Userinfo"
 USER_ID_CLAIM = "sub"  # Standard OpenID Connect claim for subject (user ID)
 
-# Global CORS headers
 CORS_HEADERS = {
     "Access-Control-Allow-Origin": ALLOWED_ORIGINS,
     "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,7 +19,6 @@ locals {
 # ------------------------------------------------------------------------------
 terraform {
   required_providers {
-    # Configure the Google provider
     google = {
       source  = "hashicorp/google"
       version = "~> 6.0"
@@ -34,7 +33,6 @@ terraform {
 # ------------------------------------------------------------------------------
 # Additional modules and resources
 # ------------------------------------------------------------------------------
-# Add documentation for modules and resources here
 
 # Generate a random integer to ensure project ID uniqueness if not explicitly set.
 # This helps in creating a unique project ID suffix.
@@ -48,21 +46,17 @@ resource "random_integer" "project_id" {
 }
 
 
-# ------------------------------------------------------------------------------
-# Configure the Google Cloud provider
-# ------------------------------------------------------------------------------
 provider "google" {
-  region                = "europe-west1" # Specify the Google Cloud region
+  region                = "europe-west1"
   user_project_override = true
 }
 
 # ------------------------------------------------------------------------------
 # Create or import the Google Cloud Project
 # ------------------------------------------------------------------------------
-# This resource defines the GCP project itself.
 resource "google_project" "reomir" {
   name       = "reomir"
-  project_id = "reomir-${random_integer.project_id.result}" # Creates a unique project ID
+  project_id = "reomir-${random_integer.project_id.result}"
 
   billing_account = var.billing_account
   deletion_policy = "DELETE" # Ensures project is deleted when 'terraform destroy' is run.

--- a/terraform/modules/api/main.tf
+++ b/terraform/modules/api/main.tf
@@ -9,7 +9,6 @@
 # ------------------------------------------------------------------------------
 # Resource to enable multiple Google Cloud APIs
 # ------------------------------------------------------------------------------
-# Enables each API specified in the 'var.apis' list for the project.
 # The 'for_each' meta-argument iterates over the set of API names.
 resource "google_project_service" "project_services" {
   for_each           = toset(var.apis) # Ensures unique API names and iterates over them


### PR DESCRIPTION
I removed various inline comments across Python, JavaScript/JSX, and Terraform files that were redundant or did not provide significant value beyond what the code itself expressed.

Key changes include:
- Python: I removed obvious comments in `functions/users/main.py` and a block of commented-out code in `agent/coordinator/sub_agents/tech_news_agent.py`.
- JavaScript/JSX:
    - I removed redundant file path comments from `ChatMessageInput.jsx` and `ChatMessagesDisplay.jsx`.
    - I removed a commented-out UI element in `ChatMessagesDisplay.jsx`.
    - I added JSDoc to `ChatMessagesDisplay.jsx` and `ConsentPopup.jsx` to improve documentation for these components.
- Terraform:
    - I removed several redundant comments from `terraform/main.tf` that merely described the succeeding block of code.
    - I removed one similar redundant comment from `terraform/modules/api/main.tf`.

I preserved all pydoc, JSDoc (where pre-existing), Terraform doc comments (module headers, variable descriptions), and inline comments that provide genuine explanation for complex logic or configuration choices.